### PR TITLE
Confirm sidebar deletion popup

### DIFF
--- a/smk-sidebar-generator/assets/scripts.js
+++ b/smk-sidebar-generator/assets/scripts.js
@@ -160,7 +160,7 @@ jQuery(document).ready(function($){
 	*/
 	function smk_sbg_remove_sidebar(){
 		$('.smk_sbg_remove_sidebar').click(function(){
-			$(this).parents('.smk_sbg_one_sidebar').slideUp('medium', function() { 
+			if(window.confirm(smk_sbg_lang.s_remove)) $(this).parents('.smk_sbg_one_sidebar').slideUp('medium', function() { 
 								$(this).remove(); 
 							});
 			


### PR DESCRIPTION
The delete string is already added in sidebar_generator.php but it wasn't included in the scripts.js file. 

Now the user can confirm before a deletion goes through.
