### PR TITLE
render.php gives an error on php v8.x

### DIFF
--- a/src/render.php
+++ b/src/render.php
@@ -464,7 +464,7 @@ if( class_exists('Smk_Sidebar_Generator_Abstract')) {
 		 * @param string $sidebar_data Data for current sidebar
 		 * @return string The HTML
 		 */
-		public function fieldConditionEqualTo($name, $sidebar_data, $index = 0, $type){
+		public function fieldConditionEqualTo($name, $sidebar_data, string $index = null, $type){
 
 			$saved = ! empty( $sidebar_data['conditions'][ absint( $index ) ]['equalto'] ) ? $sidebar_data['conditions'][ absint( $index ) ]['equalto'] : '';
 


### PR DESCRIPTION
Hi,

If you use this plugin on php v8.x - the line 467 in `render.php` will return with an error.

[PHP 8.0: Deprecate required parameters after optional parameters in function/method signatures](https://php.watch/versions/8.0/deprecate-required-param-after-optional)

To remove this I added class `string` and initate with `null` for the variable `index`.
